### PR TITLE
Remove xmlbeans from classpath

### DIFF
--- a/se.redfield.knime.neo4jextension/.classpath
+++ b/se.redfield.knime.neo4jextension/.classpath
@@ -5,6 +5,5 @@
 	<classpathentry exported="true" kind="lib" path="lib/reactive-streams-1.0.3.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="lib" path="/org.apache.xmlbeans/lib/xbean.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
This classpath entry lets the build fail on Jenkins and is not needed